### PR TITLE
Enable Swift Package and expand unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ DerivedData/
 *.dSYM
 # macOS Files
 .DS_Store
+.build/

--- a/CatIt/Sources/CatItApp.swift
+++ b/CatIt/Sources/CatItApp.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import SwiftUI
 
 @main
 struct CatItApp: App {

--- a/CatIt/Sources/Repository/BreedDetailsRepository.swift
+++ b/CatIt/Sources/Repository/BreedDetailsRepository.swift
@@ -33,9 +33,9 @@ struct DefaultBreedDetailsRepository: BreedDetailsRepository {
 		self.dataSource = dataSource
 	}
 	
-	func breedImages(page: Int, limit: Int, id breedId: String) async throws -> [CatImageInfo] {
-		let endpoint = Endpoints.breedImages(page: page, limit: limit, id: breedId)
-		let breeds = try await dataSource.getCodable<[BreedImage]>(at: endpoint)
-		return breeds
-	}
+        func breedImages(page: Int, limit: Int, id breedId: String) async throws -> [CatImageInfo] {
+                let endpoint = Endpoints.breedImages(page: page, limit: limit, id: breedId)
+                let images = try await dataSource.getCodable<[CatImageInfo]>(at: endpoint)
+                return images
+        }
 }

--- a/CatIt/Sources/Repository/BreedsRepository.swift
+++ b/CatIt/Sources/Repository/BreedsRepository.swift
@@ -32,10 +32,10 @@ struct DefaultBreedsRepository: BreedsRepository {
 		self.dataSource = dataSource
 	}
 	
-	func breeds(page: Int, limit: Int) async throws -> [CatImageInfo] {
-		let endpoint = Endpoints.breeds(page: page, limit: limit)
-		let breeds = try await dataSource.getCodable<[Breed]>(at: endpoint)
-		return breeds
-	}
+        func breeds(page: Int, limit: Int) async throws -> [CatImageInfo] {
+                let endpoint = Endpoints.breeds(page: page, limit: limit)
+                let images = try await dataSource.getCodable<[CatImageInfo]>(at: endpoint)
+                return images
+        }
 	
 }

--- a/CatIt/Sources/Services/BreedDetailsService.swift
+++ b/CatIt/Sources/Services/BreedDetailsService.swift
@@ -24,10 +24,11 @@ final class BreedDetailsService: ObservableObject {
 		self.breedDetailsRepo = breedDetailsRepo
 	}
 	
-	@MainActor
-	func loadBreedDetails(for breed: String) async {
-		do {
-			//async let breed = repo.breedDetail()
+        @MainActor
+        func loadBreedDetails(for breed: String) async {
+                guard hasMore else { return }
+                do {
+                        //async let breed = repo.breedDetail()
 			let images = try await self.breedDetailsRepo.breedImages(page: currentPage, limit: limit, id: breed)
 			if images.isEmpty {
 				hasMore = false

--- a/CatIt/Sources/Services/BreedsService.swift
+++ b/CatIt/Sources/Services/BreedsService.swift
@@ -23,10 +23,11 @@ final class BreedsService: ObservableObject {
 	@Published var isLoading = false
 	private var hasMore = true
 	
-	@MainActor
-	func loadBreeds() async {
-		do {
-			let catImages = try await self.breedsRepo.breeds(page: currentPage, limit: pageLimit)
+        @MainActor
+        func loadBreeds() async {
+                guard hasMore else { return }
+                do {
+                        let catImages = try await self.breedsRepo.breeds(page: currentPage, limit: pageLimit)
 			if catImages.isEmpty {
 				hasMore = false
 			} else {

--- a/CatItTests/BreedDetailsServiceTests.swift
+++ b/CatItTests/BreedDetailsServiceTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+import SwiftUI
+@testable import CatIt
+
+final class BreedDetailsServiceTests: XCTestCase {
+    actor MockBreedDetailsRepository: BreedDetailsRepository {
+        var images: [CatImageInfo]
+        var callCount = 0
+        init(images: [CatImageInfo]) { self.images = images }
+        func breedImages(page: Int, limit: Int, id: String) async throws -> [CatImageInfo] {
+            callCount += 1
+            return images
+        }
+    }
+
+    func testLoadBreedDetailsAppendsData() async throws {
+        let breed = Breed(breedId: "abys", uuid: UUID(), name: "Abyssinian", origin: nil, description: nil)
+        let image = CatImageInfo(breedId: "img", url: "https://example.com/cat.jpg", uuid: UUID(), breeds: [breed])
+        let repo = MockBreedDetailsRepository(images: [image])
+        let service = BreedDetailsService(breedDetailsRepo: repo)
+
+        await service.loadBreedDetails(for: "abys")
+        XCTAssertEqual(service.breedImages.count, 1)
+        XCTAssertNil(service.detailsError)
+    }
+
+    func testLoadBreedDetailsStopsWhenNoMorePages() async throws {
+        let repo = MockBreedDetailsRepository(images: [])
+        let service = BreedDetailsService(breedDetailsRepo: repo)
+
+        await service.loadBreedDetails(for: "abys")
+        await service.loadBreedDetails(for: "abys")
+
+        let count = await repo.callCount
+        XCTAssertEqual(count, 1)
+    }
+}

--- a/CatItTests/CatItTests.swift
+++ b/CatItTests/CatItTests.swift
@@ -1,36 +1,8 @@
-//
-//  CatItTests.swift
-//  CatItTests
-//
-//  Created by kiranjith on 26/01/2025.
-//
-
 import XCTest
 @testable import CatIt
 
 final class CatItTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func testEmptyExample() {
+        XCTAssertTrue(true)
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/CatItTests/EntitiesTests.swift
+++ b/CatItTests/EntitiesTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import CatIt
+
+final class EntitiesTests: XCTestCase {
+    func testBreedDecodingGeneratesUniqueIDs() throws {
+        let json = """
+        {
+            "id": "abys",
+            "name": "Abyssinian",
+            "origin": "Egypt",
+            "description": "desc"
+        }
+        """.data(using: .utf8)!
+
+        let breed1 = try JSONDecoder().decode(Breed.self, from: json)
+        let breed2 = try JSONDecoder().decode(Breed.self, from: json)
+
+        XCTAssertEqual(breed1.breedId, "abys")
+        XCTAssertNotEqual(breed1.id, breed2.id)
+    }
+
+    func testCatImageInfoReturnsFirstBreed() throws {
+        let json = """
+        {
+            "id": "img1",
+            "url": "https://example.com/cat.jpg",
+            "breeds": [{
+                "id": "abc",
+                "name": "Cat",
+                "origin": "US",
+                "description": "desc"
+            }]
+        }
+        """.data(using: .utf8)!
+
+        let info = try JSONDecoder().decode(CatImageInfo.self, from: json)
+        XCTAssertEqual(info.firstBreed?.breedId, "abc")
+    }
+}

--- a/CatItTests/NavigationTests.swift
+++ b/CatItTests/NavigationTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import SwiftUI
+@testable import CatIt
+
+final class NavigationTests: XCTestCase {
+    func testPushPopAndPopToRoot() {
+        let coordinator = NavigationCoordinator()
+        coordinator.push { AnyView(Text("A")) }
+        XCTAssertEqual(coordinator.path.count, 1)
+
+        coordinator.push { AnyView(Text("B")) }
+        XCTAssertEqual(coordinator.path.count, 2)
+
+        coordinator.pop()
+        XCTAssertEqual(coordinator.path.count, 1)
+
+        coordinator.popToRoot()
+        XCTAssertTrue(coordinator.path.isEmpty)
+    }
+}

--- a/CatItTests/NetworkingTests.swift
+++ b/CatItTests/NetworkingTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import CatIt
+
+final class NetworkingTests: XCTestCase {
+    func testResponseDecodeSuccess() throws {
+        let json = """{"id":"abys","name":"Abyssinian"}""".data(using: .utf8)!
+        let response = Response(code: .httpOk, data: json)
+        let breed: Breed = try response.decode()
+        XCTAssertEqual(breed.name, "Abyssinian")
+    }
+
+    func testResponseDecodeFailureWrapsError() throws {
+        let json = "{}".data(using: .utf8)!
+        let response = Response(code: .httpOk, data: json)
+        XCTAssertThrowsError(try response.decode() as Breed) { error in
+            guard let networkingError = error as? NetworkingError else {
+                return XCTFail("Expected NetworkingError")
+            }
+            XCTAssertEqual(networkingError.code, .generic)
+        }
+    }
+
+    func testRESTDataStoreCreatesRequestWithHeaders() async throws {
+        struct DummyEndpoint: EndpointConvertible {
+            let endpoint: Endpoint
+        }
+
+        let endpoint = DummyEndpoint(endpoint: Endpoint(
+            baseUrl: URL(string: "https://example.com")!,
+            path: "v1/test",
+            queryParams: ["page": 1],
+            httpMethod: .get,
+            authorisation: .custom(apiKey: "x-api-key", value: "123")
+        ))
+
+        let store = DefaultRESTDataStore(session: URLSession(configuration: .ephemeral))
+        let request = try await store.request(for: endpoint)
+
+        XCTAssertEqual(request.allHTTPHeaderFields?["x-api-key"], "123")
+        XCTAssertTrue(request.url?.absoluteString.contains("page=1") ?? false)
+    }
+}

--- a/CatItTests/RepositoryTests.swift
+++ b/CatItTests/RepositoryTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import CatIt
+
+final class RepositoryTests: XCTestCase {
+    actor MockRESTDataStore: RESTDataStore {
+        var lastEndpoint: Endpoint?
+        var result: [CatImageInfo]
+        init(result: [CatImageInfo]) { self.result = result }
+        func request(for endpoint: EndpointConvertible) async throws -> URLRequest {
+            throw NSError(domain: "", code: 0)
+        }
+        func getCodable<Result: Decodable>(at endpoint: CodableEndpoint<Result>) async throws -> Result {
+            lastEndpoint = endpoint.endpoint
+            return result as! Result
+        }
+    }
+
+    func testBreedsRepositoryPassesCorrectEndpoint() async throws {
+        let breed = Breed(breedId: "b", uuid: UUID(), name: "name", origin: nil, description: nil)
+        let image = CatImageInfo(breedId: "1", url: "url", uuid: UUID(), breeds: [breed])
+        let store = MockRESTDataStore(result: [image])
+        let repo = DefaultBreedsRepository(dataSource: store)
+
+        let images = try await repo.breeds(page: 2, limit: 5)
+        XCTAssertEqual(images.count, 1)
+        let endpoint = await store.lastEndpoint
+        XCTAssertEqual(endpoint?.path, "v1/images/search")
+        XCTAssertEqual(endpoint?.queryParams?["page"]?.description, "2")
+        XCTAssertEqual(endpoint?.queryParams?["limit"]?.description, "5")
+    }
+
+    func testBreedDetailsRepositoryPassesCorrectEndpoint() async throws {
+        let breed = Breed(breedId: "b", uuid: UUID(), name: "name", origin: nil, description: nil)
+        let image = CatImageInfo(breedId: "1", url: "url", uuid: UUID(), breeds: [breed])
+        let store = MockRESTDataStore(result: [image])
+        let repo = DefaultBreedDetailsRepository(dataSource: store)
+
+        _ = try await repo.breedImages(page: 1, limit: 3, id: "b")
+        let endpoint = await store.lastEndpoint
+        XCTAssertEqual(endpoint?.queryParams?["breed_id"]?.description, "b")
+    }
+}

--- a/CatItTests/ServiceTests.swift
+++ b/CatItTests/ServiceTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import CatIt
+
+final class ServiceTests: XCTestCase {
+    actor MockBreedsRepository: BreedsRepository {
+        var images: [CatImageInfo]
+        var callCount = 0
+        init(images: [CatImageInfo]) { self.images = images }
+        func breeds(page: Int, limit: Int) async throws -> [CatImageInfo] {
+            callCount += 1
+            return images
+        }
+    }
+
+    func testLoadBreedsAppendsData() async throws {
+        let breedJSON = """
+        {
+            "id": "abys",
+            "name": "Abyssinian",
+            "origin": "Egypt",
+            "description": "desc"
+        }
+        """.data(using: .utf8)!
+        let breed = try JSONDecoder().decode(Breed.self, from: breedJSON)
+        let image = CatImageInfo(breedId: "img", url: "https://example.com/cat.jpg", uuid: UUID(), breeds: [breed])
+
+        let repo = MockBreedsRepository(images: [image])
+        let service = BreedsService(breedsRepo: repo)
+
+        await service.loadBreeds()
+        XCTAssertEqual(service.catImages.count, 1)
+        XCTAssertNil(service.error)
+    }
+
+    func testLoadBreedsStopsWhenNoMorePages() async throws {
+        let repo = MockBreedsRepository(images: [])
+        let service = BreedsService(breedsRepo: repo)
+
+        await service.loadBreeds() // first call sets hasMore false
+        await service.loadBreeds() // should not call repo again
+        let count = await repo.callCount
+        XCTAssertEqual(count, 1)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "CatIt",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(name: "CatIt", targets: ["CatIt"])
+    ],
+    targets: [
+        .target(name: "CatIt", path: "CatIt/Sources"),
+        .testTarget(name: "CatItTests", dependencies: ["CatIt"], path: "CatItTests")
+    ]
+)


### PR DESCRIPTION
## Summary
- fix repository decoding types
- guard pagination in services
- remove duplicate import
- add Package.swift for SwiftPM support
- expand unit tests for services, repositories and navigation

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*
- `swift test list` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68441ebb7e908332aad769d6b33a5c42